### PR TITLE
Replace underlayWidth with snapPoints

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -302,6 +302,7 @@ class SwipeableItem<T> extends React.PureComponent<Props<T>> {
 
   onAnimationEnd = ([position, snapPointRaw]: readonly number[]) => {
     if (position === 0) {
+      this.onClose();
       this.setState({ openDirection: OpenDirection.NONE });
     } else {
       this.onOpen(Math.abs(snapPointRaw));


### PR DESCRIPTION
Instead of a single fixed `underlayWidth`, pass an array of pixel values to snap to.

before:
```underlayWidthLeft={100}```

after:
```snapPointsLeft={[100]}```

to use multiple snap points:
```snapPointsLeft={[100, 300]}```