### PR TITLE
Fixes issue preventing generic types in React.ForwardRef

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -377,7 +377,9 @@ function SwipeableItem<T>(
   );
 }
 
-export default React.forwardRef(SwipeableItem);
+export default React.forwardRef(SwipeableItem) as <T>(
+  props: Props<T> & { ref?: React.ForwardedRef<SwipeableItemImperativeRef> }
+) => React.ReactElement;
 
 export function useUnderlayParams<T>() {
   const underlayContext = useContext(UnderlayContext);


### PR DESCRIPTION
Addresses #38 via a type assertion on the exported `React.ForwardRef` function