### PR TITLE
fix: error message useSwipeableItemParams not in context

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -407,7 +407,7 @@ export function useSwipeableItemParams<T>() {
     | undefined;
   if (!overlayContext) {
     throw new Error(
-      "useOverlayParams must be called from within an OverlayContext.Provider!"
+      "useSwipeableItemParams must be called from within an OverlayContext.Provider!"
     );
   }
   const underlayContext = useContext(UnderlayContext);


### PR DESCRIPTION
i spent a while scratching my head about this error given it was referencing a function i wasn't calling