### PR TITLE
Fix for dynamic snap points

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -144,12 +144,12 @@ function SwipeableItem<T>(
     return swipingLeft.value && maxSnapPointLeft
       ? Math.abs(animStatePos.value / maxSnapPointLeft)
       : 0;
-  }, []);
+  }, [maxSnapPointLeft]);
   const percentOpenRight = useDerivedValue(() => {
     return swipingRight.value && maxSnapPointRight
       ? Math.abs(animStatePos.value / maxSnapPointRight)
       : 0;
-  }, []);
+  }, [maxSnapPointRight]);
 
   const hasLeft = !!snapPointsLeft?.length;
   const hasRight = !!snapPointsRight?.length;


### PR DESCRIPTION
Without this change, if your item starts with any side closed (no snap points), and later on you update the snap points to enable that side, the side renders empty (or rather it renders but has opacity: 0 so you cannot see the underlay).